### PR TITLE
:tada: Add StackedCraftingEnv and derivative

### DIFF
--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -8,6 +8,8 @@ on: ["push"]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg  # https://github.com/orgs/community/discussions/26434
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.10

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
-
+    env:
+      MPLBACKEND: Agg  # https://github.com/orgs/community/discussions/26434
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ dmypy.json
 *.xcf
 
 .DS_store
+
+Images

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-mock
 pytest-check
 pylint
 black
+hypothesis

--- a/src/crafting/env.py
+++ b/src/crafting/env.py
@@ -125,6 +125,7 @@ class CraftingEnv(gym.Env):
         self.render_variables = None
 
         # Seeding
+        self.original_seed = seed
         self.rng_seeds = self.seed(seed)
         self.action_space.seed(seed)
         self.observation_space.seed(seed)

--- a/src/crafting/examples/simple/__main__.py
+++ b/src/crafting/examples/simple/__main__.py
@@ -1,0 +1,75 @@
+# Crafting a gym-environment to simultate inventory managment
+# Copyright (C) 2021-2022 Mathïs FEDERICO <https://www.gnu.org/licenses/>
+
+"""Main module for MineCrafting environment."""
+
+import os
+
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+from option_graph.metrics.complexity.histograms import nodes_histograms
+from option_graph.metrics.complexity.complexities import learning_complexity
+
+from crafting.env import CraftingEnv
+from crafting.examples.simple.env import (
+    StackedCraftingEnv,
+    LightStackedCraftingEnv,
+    LighterStackedCraftingEnv,
+)
+
+
+def save_solve_graph(env: CraftingEnv, plot_path: Path, unrolled_graphs=True):
+    all_options = env.world.get_all_options()
+    all_options_list = list(all_options.values())
+    used_nodes_all = nodes_histograms(all_options_list)
+
+    goal_item = env.tasks[0].goal_item
+    option_name = f"Get {goal_item}"
+    option = all_options.get(option_name)
+
+    lcomp, comp_saved = learning_complexity(option, used_nodes_all)
+    print(f"{option_name}: {lcomp} ({comp_saved})")
+
+    figsize = (16 / 2 * (env.world.n_items + 1), 9 / 2 * (env.world.n_items + 1))
+    _, ax = plt.subplots(figsize=figsize)
+    fname = f"n={env.world.n_items}"
+    fname += f"_t={lcomp + comp_saved}_s={comp_saved}_l={lcomp}"
+
+    graph = option.graph
+    if unrolled_graphs:
+        graph = graph.unrolled_graph
+        fname += "_unrolled"
+
+    graph.draw(ax, draw_options_hulls=True)
+    path = plot_path / fname
+    plt.tight_layout()
+    os.makedirs(plot_path, exist_ok=True)
+    plt.savefig(path, dpi=240)
+    print(f"Saved solve_graph at {path}")
+
+
+def save_requirement_graph(env: CraftingEnv, plot_path: Path):
+    _, ax = plt.subplots(figsize=(16, 9))
+    env.world.draw_requirements_graph(ax)
+    path = plot_path / f"n={n_items}_requirement_graph"
+    os.makedirs(plot_path, exist_ok=True)
+    plt.savefig(path, dpi=240)
+    print(f"Saved requirement_graph at {path}")
+
+
+if __name__ == "__main__":
+
+    for n_items in range(9, 11):
+        envs = [
+            LightStackedCraftingEnv(n_items, 1),
+            LightStackedCraftingEnv(n_items, 2),
+            LightStackedCraftingEnv(n_items, 3),
+            LighterStackedCraftingEnv(n_items, 3),
+            LighterStackedCraftingEnv(n_items, 4),
+            StackedCraftingEnv(n_items),
+        ]
+        for env in envs:
+            plot_path = Path("Images") / "graphs" / env.name
+            save_solve_graph(env, plot_path / "solve", unrolled_graphs=True)
+            save_requirement_graph(env, plot_path / "requirement_graph")

--- a/src/crafting/examples/simple/__main__.py
+++ b/src/crafting/examples/simple/__main__.py
@@ -32,7 +32,7 @@ def save_solve_graph(env: CraftingEnv, plot_path: Path, unrolled_graphs=True):
     print(f"{option_name}: {lcomp} ({comp_saved})")
 
     figsize = (16 / 2 * (env.world.n_items + 1), 9 / 2 * (env.world.n_items + 1))
-    _, ax = plt.subplots(figsize=figsize)
+    fig, ax = plt.subplots(figsize=figsize)
     fname = f"n={env.world.n_items}"
     fname += f"_t={lcomp + comp_saved}_s={comp_saved}_l={lcomp}"
 
@@ -47,20 +47,22 @@ def save_solve_graph(env: CraftingEnv, plot_path: Path, unrolled_graphs=True):
     os.makedirs(plot_path, exist_ok=True)
     plt.savefig(path, dpi=240)
     print(f"Saved solve_graph at {path}")
+    plt.close(fig)
 
 
 def save_requirement_graph(env: CraftingEnv, plot_path: Path):
-    _, ax = plt.subplots(figsize=(16, 9))
+    fig, ax = plt.subplots(figsize=(16, 9))
     env.world.draw_requirements_graph(ax)
     path = plot_path / f"n={n_items}_requirement_graph"
     os.makedirs(plot_path, exist_ok=True)
     plt.savefig(path, dpi=240)
     print(f"Saved requirement_graph at {path}")
+    plt.close(fig)
 
 
 if __name__ == "__main__":
 
-    for n_items in range(9, 11):
+    for n_items in range(3, 11):
         envs = [
             LightStackedCraftingEnv(n_items, 1),
             LightStackedCraftingEnv(n_items, 2),

--- a/src/crafting/examples/simple/__main__.py
+++ b/src/crafting/examples/simple/__main__.py
@@ -53,15 +53,14 @@ def save_solve_graph(env: CraftingEnv, plot_path: Path, unrolled_graphs=True):
 def save_requirement_graph(env: CraftingEnv, plot_path: Path):
     fig, ax = plt.subplots(figsize=(16, 9))
     env.world.draw_requirements_graph(ax)
-    path = plot_path / f"n={n_items}_requirement_graph"
+    path = plot_path / f"n={env.world.n_items}_requirement_graph"
     os.makedirs(plot_path, exist_ok=True)
     plt.savefig(path, dpi=240)
     print(f"Saved requirement_graph at {path}")
     plt.close(fig)
 
 
-if __name__ == "__main__":
-
+def save__all_envs_graphs():
     for n_items in range(3, 11):
         envs = [
             LightStackedCraftingEnv(n_items, 1),
@@ -75,3 +74,7 @@ if __name__ == "__main__":
             plot_path = Path("Images") / "graphs" / env.name
             save_solve_graph(env, plot_path / "solve", unrolled_graphs=True)
             save_requirement_graph(env, plot_path / "requirement_graph")
+
+
+if __name__ == "__main__":
+    save__all_envs_graphs()

--- a/src/crafting/examples/simple/env.py
+++ b/src/crafting/examples/simple/env.py
@@ -16,7 +16,7 @@ from crafting.world.world import World
 from crafting.player.player import Player
 from crafting.player.inventory import Inventory
 
-from crafting.task import TaskList, TaskObtainItem
+from crafting.task import TaskList, TaskObtainItem, RewardShaping
 
 from crafting.world.zones import Zone
 from crafting.world.items import Item, ItemStack
@@ -52,15 +52,18 @@ class BaseSimpleCraftingEnv(CraftingEnv):
         if "max_step" not in kwargs:
             kwargs["max_step"] = 2**n_items
         player = Player(Inventory(world.items), initial_zone)
-        tasks = TaskList(
-            [TaskObtainItem(world, world.items[-1], goal_reward=2**n_items)],
-            can_end=[True],
+        reward_shaping = kwargs.pop("reward_shaping", 0)
+        task = TaskObtainItem(
+            world,
+            world.items[-1],
+            goal_reward=2**n_items,
+            reward_shaping=reward_shaping,
         )
         super().__init__(
             world=world,
             player=player,
             seed=0,
-            tasks=tasks,
+            tasks=TaskList([task], can_end=[True]),
             **kwargs,
         )
 

--- a/src/crafting/examples/simple/env.py
+++ b/src/crafting/examples/simple/env.py
@@ -133,7 +133,10 @@ class LightStackedCraftingEnv(BaseSimpleCraftingEnv):
 
     def __init__(self, n_items: int, n_required_previous: int = 2, **kwargs):
         self.n_required_previous = n_required_previous
-        env_name = f"LightStackedCrafting-{self.n_required_previous}"
+        if self.n_required_previous == 1:
+            env_name = "LinearStackedCrafting"
+        else:
+            env_name = f"LightStackedCrafting-{self.n_required_previous}"
         super().__init__(n_items, name=env_name, **kwargs)
 
     def _build_recipes(self, items: List[Item]) -> List[Recipe]:
@@ -172,7 +175,10 @@ class LighterStackedCraftingEnv(BaseSimpleCraftingEnv):
 
     def __init__(self, n_items: int, n_required_previous: int = 3, **kwargs):
         self.n_required_previous = n_required_previous
-        env_name = f"LighterStackedCrafting-{self.n_required_previous}"
+        if self.n_required_previous <= 2:
+            env_name = "LinearStackedCrafting"
+        else:
+            env_name = f"LighterStackedCrafting-{self.n_required_previous}"
         super().__init__(n_items, name=env_name, **kwargs)
 
     def _build_recipes(self, items: List[Item]) -> List[Recipe]:

--- a/src/crafting/examples/simple/env.py
+++ b/src/crafting/examples/simple/env.py
@@ -1,0 +1,201 @@
+# Crafting a gym-environment to simultate inventory managment
+# Copyright (C) 2021-2022 Mathïs FEDERICO <https://www.gnu.org/licenses/>
+
+""" Random Crafting Environment
+
+Generate a random Crafting environment using basic constructor rules.
+
+"""
+
+from typing import List, Tuple
+
+
+from crafting.env import CraftingEnv
+from crafting.world.world import World
+
+from crafting.player.player import Player
+from crafting.player.inventory import Inventory
+
+from crafting.task import TaskList, TaskObtainItem
+
+from crafting.world.zones import Zone
+from crafting.world.items import Item, ItemStack
+from crafting.world.recipes import Recipe
+
+
+class BaseSimpleCraftingEnv(CraftingEnv):
+
+    """Base for simple handcrafted environments."""
+
+    def __init__(
+        self,
+        n_items: int,
+        **kwargs,
+    ):
+        """Base for simple handcrafted environments.
+
+        No zones, or tools dynamics.
+
+        Args:
+            n_items: Total number of items to generate.
+
+        Kwargs:
+            max_step: The maximum number of steps until done.
+            verbose: Verbosity level. {0: quiet, 1: print actions results}.
+            observe_legal_actions: If True, add legal actions to observations.
+            fail_penalty: Reward penalty for each non-successful action.
+            timestep_penalty: Reward penalty for each timestep.
+
+        """
+
+        world, initial_zone = self.build_world(n_items=n_items)
+        if "max_step" not in kwargs:
+            kwargs["max_step"] = 2**n_items
+        player = Player(Inventory(world.items), initial_zone)
+        tasks = TaskList(
+            [TaskObtainItem(world, world.items[-1], goal_reward=2**n_items)],
+            can_end=[True],
+        )
+        super().__init__(
+            world=world,
+            player=player,
+            seed=0,
+            tasks=tasks,
+            **kwargs,
+        )
+
+    def build_world(self, n_items: int) -> Tuple[World, Zone]:
+        """Initialise a linerarly stacked World.
+
+        Args:
+            n_items: Total number of items to generate.
+
+        Returns:
+            A linerarly stacked World.
+
+        """
+        items = [Item(i, f"{i}") for i in range(n_items)]
+        zone = Zone(0, "zone", items=[items[0]])
+
+        recipes = self._build_recipes(items)
+
+        world = World(zones=[zone], items=items, recipes=recipes)
+        return world, zone
+
+    def _build_recipes(self, items: List[Item]) -> List[Recipe]:
+        raise NotImplementedError
+
+
+class StackedCraftingEnv(BaseSimpleCraftingEnv):
+
+    """Stacked, an exponentially hierarchical Environment.
+
+    Item n requires all previous items (0 to n-1).
+
+    """
+
+    def __init__(self, n_items: int, **kwargs):
+        super().__init__(n_items, name="StackedCrafting", **kwargs)
+
+    def _build_recipes(self, items: List[Item]) -> List[Recipe]:
+        """Build recipes to make every item accessible.
+
+        Args:
+            items: List of items.
+
+        Returns:
+            List of craft recipes.
+
+        """
+        recipes = []
+
+        for item in items[1:]:
+            inputs = [ItemStack(items[item_id]) for item_id in range(item.item_id)]
+            outputs = [ItemStack(items[item.item_id])]
+
+            # Build recipe
+            new_recipe = Recipe(len(recipes), inputs=inputs, outputs=outputs)
+            recipes.append(new_recipe)
+
+        return recipes
+
+
+class LightStackedCraftingEnv(BaseSimpleCraftingEnv):
+
+    """LightStacked, a lighter version of the StackedCrafting Environment.
+
+    Item n requires the k previous items (n-k to n-1).
+
+    """
+
+    def __init__(self, n_items: int, n_required_previous: int = 2, **kwargs):
+        self.n_required_previous = n_required_previous
+        env_name = f"LightStackedCrafting-{self.n_required_previous}"
+        super().__init__(n_items, name=env_name, **kwargs)
+
+    def _build_recipes(self, items: List[Item]) -> List[Recipe]:
+        """Build recipes to make every item accessible.
+
+        Args:
+            items: List of items.
+
+        Returns:
+            List of craft recipes.
+
+        """
+        recipes = []
+
+        for item in items[1:]:
+            low_id = max(0, item.item_id - self.n_required_previous)
+            inputs = [
+                ItemStack(items[item_id]) for item_id in range(low_id, item.item_id)
+            ]
+            outputs = [ItemStack(items[item.item_id])]
+
+            # Build recipe
+            new_recipe = Recipe(len(recipes), inputs=inputs, outputs=outputs)
+            recipes.append(new_recipe)
+
+        return recipes
+
+
+class LighterStackedCraftingEnv(BaseSimpleCraftingEnv):
+
+    """LighterStacked, a lighter version of the LightStackedCraftingEnv Environment.
+
+    Item n requires the k previous items except the item n-2 (n-k to n-3 and n-1).
+
+    """
+
+    def __init__(self, n_items: int, n_required_previous: int = 3, **kwargs):
+        self.n_required_previous = n_required_previous
+        env_name = f"LighterStackedCrafting-{self.n_required_previous}"
+        super().__init__(n_items, name=env_name, **kwargs)
+
+    def _build_recipes(self, items: List[Item]) -> List[Recipe]:
+        """Build recipes to make every item accessible.
+
+        Args:
+            items: List of items.
+
+        Returns:
+            List of craft recipes.
+
+        """
+        recipes = []
+
+        for item in items[1:]:
+            inputs = [ItemStack(items[item.item_id - 1])]
+            if item.item_id >= 3:
+                low_id = max(0, item.item_id - self.n_required_previous)
+                inputs += [
+                    ItemStack(items[item_id])
+                    for item_id in range(low_id, item.item_id - 2)
+                ]
+            outputs = [ItemStack(items[item.item_id])]
+
+            # Build recipe
+            new_recipe = Recipe(len(recipes), inputs=inputs, outputs=outputs)
+            recipes.append(new_recipe)
+
+        return recipes

--- a/src/crafting/options/actions.py
+++ b/src/crafting/options/actions.py
@@ -25,7 +25,7 @@ class SearchItem(Action):
         name = f"Search {item}"
         image = np.array(load_or_create_image(world, item))
         action = world.action("get", item.item_id)
-        super().__init__(action, name=name, image=image)
+        super().__init__(action, name=name, image=image, complexity=1)
         self.item = item
 
 
@@ -37,7 +37,7 @@ class MoveToZone(Action):
         name = f"Move to {zone}"
         image = np.array(load_or_create_image(world, zone))
         action = world.action("move", zone.zone_id)
-        super().__init__(action, name=name, image=image)
+        super().__init__(action, name=name, image=image, complexity=1)
         self.zone = zone
 
 
@@ -55,5 +55,5 @@ class CraftRecipe(Action):
 
         image = np.array(load_or_create_image(world, obj))
         action = world.action("craft", recipe.recipe_id)
-        super().__init__(action, name=name, image=image)
+        super().__init__(action, name=name, image=image, complexity=1)
         self.recipe = recipe

--- a/src/crafting/options/feature_conditions.py
+++ b/src/crafting/options/feature_conditions.py
@@ -24,7 +24,7 @@ class HasItem(FeatureCondition):
         name = f"Has {quantity} {item}?"
         conditon_text = f"{quantity}" if quantity > 1 else ""
         image = load_or_create_image(world, item, text=conditon_text)
-        super().__init__(name=name, image=np.array(image))
+        super().__init__(name=name, image=np.array(image), complexity=1)
 
         self.world = world
         self.item = item
@@ -43,7 +43,7 @@ class IsInZone(FeatureCondition):
     def __init__(self, zone: "Zone", world: "World") -> None:
         name = f"Is in {zone}?"
         image = np.array(load_or_create_image(world, zone))
-        super().__init__(name=name, image=image)
+        super().__init__(name=name, image=image, complexity=1)
 
         self.world = world
         self.zone = zone
@@ -61,7 +61,7 @@ class HasProperty(FeatureCondition):
     def __init__(self, prop: str, world: "World") -> None:
         name = f"Has property '{prop}' ?"
         image = np.array(load_or_create_image(world, prop))
-        super().__init__(name=name, image=image)
+        super().__init__(name=name, image=image, complexity=1)
 
         self.world = world
         self.prop = prop

--- a/src/crafting/task.py
+++ b/src/crafting/task.py
@@ -248,16 +248,21 @@ class TaskObtainItem(Task):
         super().__init__(f"obtain_{item}", world)
         self.goal_item = item
         self.add_achivement_getitem(self.goal_item, goal_reward, end_task=True)
+        self._init_reward_shaping(reward_shaping, shaping_value)
 
-        # Reward shaping
+    def _init_reward_shaping(self, reward_shaping: RewardShaping, shaping_value: float):
         achivement_items: List["Item"] = []
-        if reward_shaping is None or reward_shaping == RewardShaping.NONE:
+        if reward_shaping is None:
+            reward_shaping = RewardShaping.NONE
+
+        reward_shaping = RewardShaping(reward_shaping)
+        if reward_shaping == RewardShaping.NONE:
             pass
         elif reward_shaping == RewardShaping.ALL:
-            achivement_items = world.items
+            achivement_items = self.world.items
         elif reward_shaping in (RewardShaping.ALL_USEFUL, RewardShaping.DIRECT_USEFUL):
-            all_options = world.get_all_options()
-            solving_option = all_options[f"Get {item}"]
+            all_options = self.world.get_all_options()
+            solving_option = all_options[f"Get {self.goal_item}"]
             graph = solving_option.graph
             if reward_shaping == RewardShaping.ALL_USEFUL:
                 graph = graph.unrolled_graph

--- a/src/crafting/task.py
+++ b/src/crafting/task.py
@@ -245,7 +245,7 @@ class TaskObtainItem(Task):
             shaping_value (float, optional): Value used for reward shaping if any.
                 Defaults to 1.
         """
-        super().__init__(f"obtain_{item}", world)
+        super().__init__(name=f"obtain_{item}", world=world)
         self.goal_item = item
         self.add_achivement_getitem(self.goal_item, goal_reward, end_task=True)
         self._init_reward_shaping(reward_shaping, shaping_value)

--- a/src/crafting/task.py
+++ b/src/crafting/task.py
@@ -112,7 +112,7 @@ class TaskList:
         can_end: Union[List[bool], Dict[str, bool]] = None,
         early_stopping: str = "all",
     ):
-        """_summary_
+        """A list of tasks of a Crafting environment.
 
         Args:
             tasks (List[Task]): List of tasks to compose the list.
@@ -378,8 +378,8 @@ def get_task_by_complexity(
 
 def get_task(
     world: "World",
-    task_name: str = "",
     task_complexity: float = None,
+    task_name: Optional[str] = None,
     cache_path: Optional[str] = None,
     random_task: bool = False,
     seed: int = None,
@@ -414,6 +414,7 @@ def get_task(
     Returns:
         Task: Built task.
     """
+    task_name = task_name if task_name is not None else ""
     random_task = random_task or "random" in task_name
     assert random_task or task_name is not None or task_complexity is not None
 

--- a/src/crafting/task.py
+++ b/src/crafting/task.py
@@ -383,8 +383,8 @@ def get_task_by_complexity(
 
 def get_task(
     world: "World",
-    task_complexity: float = None,
     task_name: Optional[str] = None,
+    task_complexity: float = None,
     cache_path: Optional[str] = None,
     random_task: bool = False,
     seed: int = None,

--- a/tests/integration/examples/random/test_env.py
+++ b/tests/integration/examples/random/test_env.py
@@ -9,20 +9,20 @@ from networkx import is_isomorphic
 from crafting.examples.random.env import RandomCraftingEnv
 
 
-class TestTasks:
+class TestRandomCrafting:
 
-    """Tasks of the MineCrafting environment"""
+    """Test the RandomCrafting environment"""
 
     @pytest.fixture(autouse=True)
     def setup(self):
         """Setup test fixtures."""
         n_items = 10
         self.env_settings = {
-            'n_items': n_items,
-            'n_tools': int(0.1*n_items),
-            'n_findables': int(0.3*n_items),
-            'n_required_tools': [0.25, 0.4, 0.2, 0.1, 0.05],
-            'n_inputs_per_craft': [0.1, 0.6, 0.3],
+            "n_items": n_items,
+            "n_tools": int(0.1 * n_items),
+            "n_findables": int(0.3 * n_items),
+            "n_required_tools": [0.25, 0.4, 0.2, 0.1, 0.05],
+            "n_inputs_per_craft": [0.1, 0.6, 0.3],
         }
 
     def test_same_seed_same_requirements_graph(self):

--- a/tests/integration/examples/simple/__init__.py
+++ b/tests/integration/examples/simple/__init__.py
@@ -1,0 +1,2 @@
+# Crafting a gym-environment to simultate inventory managment
+# Copyright (C) 2021-2022 Mathïs FEDERICO <https://www.gnu.org/licenses/>

--- a/tests/integration/examples/simple/test_env.py
+++ b/tests/integration/examples/simple/test_env.py
@@ -15,8 +15,9 @@ from crafting.examples.simple.env import (
 )
 
 
-def test_stacked_requirements_graph():
-    env = StackedCraftingEnv(n_items=4)
+@given(integers(3, 8))
+def test_stacked_requirements_graph(n_items: int):
+    env = StackedCraftingEnv(n_items=n_items)
     expected_graph = DiGraph()
     for item in env.world.items:
         for required_id in range(item.item_id):
@@ -25,9 +26,11 @@ def test_stacked_requirements_graph():
     check.is_true(is_isomorphic(env.world.get_requirements_graph(), expected_graph))
 
 
-@given(integers(2, 6))
-def test_lightstacked_requirements_graph(n_required_previous: int):
-    env = LightStackedCraftingEnv(n_items=4, n_required_previous=n_required_previous)
+@given(integers(3, 8), integers(2, 6))
+def test_lightstacked_requirements_graph(n_items: int, n_required_previous: int):
+    env = LightStackedCraftingEnv(
+        n_items=n_items, n_required_previous=n_required_previous
+    )
     expected_graph = DiGraph()
     for item in env.world.items:
         min_idx = max(0, item.item_id - n_required_previous)
@@ -37,9 +40,11 @@ def test_lightstacked_requirements_graph(n_required_previous: int):
     check.is_true(is_isomorphic(env.world.get_requirements_graph(), expected_graph))
 
 
-@given(integers(3, 6))
-def test_lighterstacked_requirements_graph(n_required_previous: int):
-    env = LighterStackedCraftingEnv(n_items=4, n_required_previous=n_required_previous)
+@given(integers(3, 8), integers(3, 6))
+def test_lighterstacked_requirements_graph(n_items: int, n_required_previous: int):
+    env = LighterStackedCraftingEnv(
+        n_items=n_items, n_required_previous=n_required_previous
+    )
     expected_graph = DiGraph()
     for item in env.world.items:
         if item.item_id > 0:

--- a/tests/integration/examples/simple/test_env.py
+++ b/tests/integration/examples/simple/test_env.py
@@ -1,0 +1,51 @@
+# Crafting a gym-environment to simultate inventory managment
+# Copyright (C) 2021-2022 Mathïs FEDERICO <https://www.gnu.org/licenses/>
+
+import pytest_check as check
+
+from hypothesis import given
+from hypothesis.strategies import integers
+
+from networkx import is_isomorphic, DiGraph
+
+from crafting.examples.simple.env import (
+    StackedCraftingEnv,
+    LightStackedCraftingEnv,
+    LighterStackedCraftingEnv,
+)
+
+
+def test_stacked_requirements_graph():
+    env = StackedCraftingEnv(n_items=4)
+    expected_graph = DiGraph()
+    for item in env.world.items:
+        for required_id in range(item.item_id):
+            expected_graph.add_edge(required_id, item.item_id)
+
+    check.is_true(is_isomorphic(env.world.get_requirements_graph(), expected_graph))
+
+
+@given(integers(2, 6))
+def test_lightstacked_requirements_graph(n_required_previous: int):
+    env = LightStackedCraftingEnv(n_items=4, n_required_previous=n_required_previous)
+    expected_graph = DiGraph()
+    for item in env.world.items:
+        min_idx = max(0, item.item_id - n_required_previous)
+        for required_id in range(min_idx, item.item_id):
+            expected_graph.add_edge(required_id, item.item_id)
+
+    check.is_true(is_isomorphic(env.world.get_requirements_graph(), expected_graph))
+
+
+@given(integers(3, 6))
+def test_lighterstacked_requirements_graph(n_required_previous: int):
+    env = LighterStackedCraftingEnv(n_items=4, n_required_previous=n_required_previous)
+    expected_graph = DiGraph()
+    for item in env.world.items:
+        if item.item_id > 0:
+            expected_graph.add_edge(item.item_id - 1, item.item_id)
+        min_idx = max(0, item.item_id - n_required_previous)
+        for required_id in range(min_idx, item.item_id - 2):
+            expected_graph.add_edge(required_id, item.item_id)
+
+    check.is_true(is_isomorphic(env.world.get_requirements_graph(), expected_graph))

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -36,6 +36,7 @@ class DummyItem:
     def __hash__(self) -> int:
         return self.name.__hash__()
 
+
 @dataclass
 class DummyOption:
     """DummyItem"""
@@ -48,6 +49,7 @@ class DummyOption:
 
     def __hash__(self) -> int:
         return self.name.__hash__()
+
 
 class DummyWorld:
     """DummyWorld"""
@@ -532,7 +534,7 @@ class TestGetTask:
 
     def test_by_name(self):
         """should get task by name by default."""
-        get_task(self.world, "obtain_2")
+        get_task(self.world, task_name="obtain_2")
 
         check.is_false(self.random_mocker.called)
         check.is_false(self.complexity_mocker.called)
@@ -552,7 +554,7 @@ class TestGetTask:
     def test_random_in_name(self):
         """should get a random obtain_item task if random in task_name."""
         seed = 42
-        get_task(self.world, "obtain_random", seed=seed)
+        get_task(self.world, task_name="obtain_random", seed=seed)
 
         check.is_true(self.random_mocker.called)
         check.is_false(self.complexity_mocker.called)

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -268,13 +268,18 @@ class TestTaskListStackDones:
             tests._stacked_dones()
 
 
+def dummy_init(self, **kwargs):
+    for arg_name, arg_value in kwargs.items():
+        setattr(self, arg_name, arg_value)
+
+
 class TestTaskObtainItem:
     """TaskObtainItem"""
 
     @pytest.fixture(autouse=True)
     def setup(self, mocker: MockerFixture):
         """Setup reused fixtures."""
-        self.init_mocker = mocker.patch("crafting.task.Task.__init__")
+        self.init_mocker = mocker.patch("crafting.task.Task.__init__", dummy_init)
         self.add_achivement_mocker = mocker.patch(
             "crafting.task.Task.add_achivement_getitem"
         )
@@ -343,9 +348,6 @@ class TestTaskObtainItem:
         """should have given item as goal_item and ending achivement."""
 
         task = TaskObtainItem(world=self.dummy_world, item=self.dummy_item)
-        self.init_mocker.assert_called_with(
-            f"obtain_{self.dummy_item}", self.dummy_world
-        )
         check.equal(task.goal_item, self.dummy_item)
         self.add_achivement_mocker.assert_called_with(
             self.dummy_item, 10, end_task=True


### PR DESCRIPTION
StackedCraftingEnv and derivatives allow to see extreme cases of hierarchical environments.

Item n in StackedCrafting require all the previous items in its recipe (Items from 0 to n-1). Hence the total complexity grows exponentially, but the learning complexity only grows nearly linearly:

N_items=4: Complexities (Total= 15, Saved=5, Learn=10)
![n=4_t=15_s=5_l=10_unrolled](https://user-images.githubusercontent.com/60117466/204179655-90615657-ac80-469a-98fe-deee26fab1fe.png)

N_items=5: Complexities (Total= 31, Saved=16, Learn=15)
![n=5_t=31_s=16_l=15_unrolled](https://user-images.githubusercontent.com/60117466/204179522-64d6a4f6-37aa-4d18-9c09-5a3ee054936d.png)

N_items=6: Complexities (Total= 63, Saved=42, Learn=21)
![n=6_t=63_s=42_l=21_unrolled](https://user-images.githubusercontent.com/60117466/204179923-25712ec7-0a69-4f53-b885-4e89ce559c2b.png)

...

N_items=10: Complexities (Total= 1023, Saved=968, Learn=55)
![n=10_t=1023_s=968_l=55_unrolled](https://user-images.githubusercontent.com/60117466/204180001-6ef1e9ae-91ed-42e6-a4b9-fb51bcade64b.png)

LightStackedCraftingEnv and LighterStackedCraftingEnv provide some less agressive increases:

Light:  N_items=10, N_required_previous = 2: Complexities (Total= 285, Saved=258, Learn=27)
![n=10_t=285_s=258_l=27_unrolled](https://user-images.githubusercontent.com/60117466/204180345-6e8c933a-7f8d-40bf-9099-d276abc44d15.png)

Lighter: N_items=10, N_required_previous = 3: Complexities (Total= 117, Saved=65, Learn=52)
![n=10_t=117_s=65_l=52_unrolled](https://user-images.githubusercontent.com/60117466/204180314-6ed54107-5f32-4c55-bb78-236a95df69fb.png)

The other extreme is the linear case, where no complexity can be saved by re-using knowledge.
Light:  N_items=10, N_required_previous = 1: Complexities (Total= 19, Saved=0, Learn=19)
![n=10_t=19_s=0_l=19_unrolled](https://user-images.githubusercontent.com/60117466/204180869-73e01c42-8af5-4744-9250-0b85a19bc5a2.png)
