### PR TITLE
Fix: add missing DOIs for citations

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -6,7 +6,7 @@
   pages = {102012},
   year = {2025},
   issn = {2352-7110},
-  doi = {10.1016/j.softx.2024.102012},
+  doi = {10.1016/j.softx.2024.102012}
 }
 
 @inproceedings{hafner2022benchmarking,
@@ -14,7 +14,8 @@
   author={Danijar Hafner},
   booktitle={International Conference on Learning Representations},
   year={2022},
-  url={https://openreview.net/forum?id=1W0z96MFEoH}
+  url={https://openreview.net/forum?id=1W0z96MFEoH},
+  doi={10.48550/arXiv.2109.06780}
 }
 
 
@@ -41,6 +42,7 @@
   month        = dec,
   year         = {2023},
   volume       = 36,
+  doi = {10.48550/arXiv.2306.13831},
 }
 
 @article{kuttler2020nethack,
@@ -49,7 +51,8 @@
   journal={Advances in Neural Information Processing Systems},
   volume={33},
   pages={7671--7684},
-  year={2020}
+  year={2020},
+  doi = {10.48550/arxiv.2006.13760},
 }
 
 @InProceedings{milani2020minerl2019,
@@ -64,7 +67,8 @@
   month = 	 dec,
   pdf = 	 {http://proceedings.mlr.press/v123/milani20a/milani20a.pdf},
   url = 	 {https://proceedings.mlr.press/v123/milani20a.html},
-  abstract = 	 {To facilitate research in the direction of sample efficient reinforcement learning, we held the MineRL Competition on Sample Efficient Reinforcement Learning Using Human Priors at the Thirty-third Conference on Neural Information Processing Systems (NeurIPS 2019). The primary goal of this competition was to promote the development of algorithms that use human demonstrations alongside reinforcement learning to reduce the number of samples needed to solve complex, hierarchical, and sparse environments. We describe the competition, outlining the primary challenge, the competition design, and the resources that we provided to the participants. We provide an overview of the top solutions, each of which use deep reinforcement learning and/or imitation learning. We also discuss the impact of our organizational decisions on the competition and future directions for improvement.}
+  abstract = 	 {To facilitate research in the direction of sample efficient reinforcement learning, we held the MineRL Competition on Sample Efficient Reinforcement Learning Using Human Priors at the Thirty-third Conference on Neural Information Processing Systems (NeurIPS 2019). The primary goal of this competition was to promote the development of algorithms that use human demonstrations alongside reinforcement learning to reduce the number of samples needed to solve complex, hierarchical, and sparse environments. We describe the competition, outlining the primary challenge, the competition design, and the resources that we provided to the participants. We provide an overview of the top solutions, each of which use deep reinforcement learning and/or imitation learning. We also discuss the impact of our organizational decisions on the competition and future directions for improvement.},
+  doi = {10.48550/arxiv.2003.05012}
 }
 
 @article{guss2021minerl2020,
@@ -110,7 +114,8 @@
   booktitle={International conference on machine learning},
   pages={2048--2056},
   year={2020},
-  organization={PMLR}
+  organization={PMLR},
+  doi={10.48550/arxiv.1912.01588}
 }
 
 @inproceedings{10.5555/2832747.2832830,
@@ -124,7 +129,8 @@
   pages = {4148–4152},
   numpages = {5},
   location = {Buenos Aires, Argentina},
-  series = {IJCAI'15}
+  series = {IJCAI'15},
+  doi={10.1613/jair.3912}
 }
 
 @article{deepmindlab,
@@ -158,7 +164,8 @@
   eprint       = {1612.03801},
   timestamp    = {Mon, 13 Aug 2018 16:48:18 +0200},
   biburl       = {https://dblp.org/rec/journals/corr/BeattieLTWWKLGV16.bib},
-  bibsource    = {dblp computer science bibliography, https://dblp.org}
+  bibsource    = {dblp computer science bibliography, https://dblp.org},
+  doi={10.48550/arXiv.1612.03801},
 }
 
 
@@ -177,6 +184,7 @@
   editor={Alan Fern and Vicenç Gómez and Anders Jonsson and Michael Katz and Hector Palacios and Scott Sanner},
   year={2020},
   pages={1--6},
+  doi={10.48550/arxiv.2002.06432}
 }
 
 @techreport{PDDL,
@@ -222,7 +230,8 @@
   publisher =    {PMLR},
   pdf = 	 {https://proceedings.mlr.press/v176/hambro22a/hambro22a.pdf},
   url = 	 {https://proceedings.mlr.press/v176/hambro22a.html},
-  abstract = 	 {In this report, we summarize the takeaways from the first NeurIPS 2021 NetHack Challenge. Participants were tasked with developing a program or agent that can win (i.e., ’ascend’ in) the popular dungeon-crawler game of NetHack by interacting with the NetHack Learning Environment (NLE), a scalable, procedurally generated, and challenging Gym environment for reinforcement learning (RL). The challenge showcased community-driven progress in AI with many diverse approaches significantly beating the previously best results on NetHack. Furthermore, it served as a direct comparison between neural (e.g., deep RL) and symbolic AI, as well as hybrid systems, demonstrating that on NetHack symbolic bots currently outperform deep RL by a large margin. Lastly, no agent got close to winning the game, illustrating NetHack’s suitability as a long-term benchmark for AI research.}
+  abstract = 	 {In this report, we summarize the takeaways from the first NeurIPS 2021 NetHack Challenge. Participants were tasked with developing a program or agent that can win (i.e., ’ascend’ in) the popular dungeon-crawler game of NetHack by interacting with the NetHack Learning Environment (NLE), a scalable, procedurally generated, and challenging Gym environment for reinforcement learning (RL). The challenge showcased community-driven progress in AI with many diverse approaches significantly beating the previously best results on NetHack. Furthermore, it served as a direct comparison between neural (e.g., deep RL) and symbolic AI, as well as hybrid systems, demonstrating that on NetHack symbolic bots currently outperform deep RL by a large margin. Lastly, no agent got close to winning the game, illustrating NetHack’s suitability as a long-term benchmark for AI research.},
+  doi={10.48550/arxiv.2203.11889}
 }
 
 @article{10.1098/rstb.2013.0480,
@@ -259,7 +268,8 @@
   volume={28},
   pages={2944--2952},
   isbn = {978-1-5108-2502-4},
-  year={2015}
+  year={2015},
+  doi={10.48550/arxiv.1510.09142}
 }
 @inproceedings{nachum2018data,
   title={Data-efficient hierarchical reinforcement learning},
@@ -270,7 +280,8 @@
   volume={31},
   pages={3303--3313},
   isbn={978-1-5108-8447-2},
-  year={2018}
+  year={2018},
+  doi={10.48550/arxiv.1805.08296}
 }
 
 @article{Chollet2019OnTM,


### PR DESCRIPTION
Added missing DOIs for citations. The rest are either too old to have a DOI or the publisher does not provide a DOI.